### PR TITLE
Bug fix for "old" emojis (pre-Emoji v1.0)

### DIFF
--- a/crimsobot/utils/image.py
+++ b/crimsobot/utils/image.py
@@ -69,10 +69,14 @@ def bigmoji(emoji: str) -> Tuple[Optional[str], Optional[str]]:
             else:  # numbers zero-nine
                 filename = '3' + filename
 
+        if filename.endswith('-fe0f'):  # "old" emojis (pre-Emoji v1.0 release)
+            filename = filename.replace('-fe0f','')
+
         # test if real file
         try:
             path = c.clib_path_join('emoji', filename + '.png')
             emoji_type = 'file'
+            print(path, emoji_type)
             f = open(path, 'rb')
             f.close()
         except OSError:


### PR DESCRIPTION
This fix lets bigmoji find the file for emojis that have a "non-fully-qualified twin" so to speak.

For example, some emojis existed as Unicode symbols before the release of Emoji v1.0. They have a small difference in their code points. For example (from http://unicode.org/Public/emoji/5.0/emoji-test.txt):

```
263A FE0F                                  ; fully-qualified     # ☺️ smiling face
263A                                       ; non-fully-qualified # ☺ smiling face
```

The files in data/emojis for these "twin" pairs do NOT have the "-fe0f" at the end of the filename, so bigmoji couldn't find them when queried. Now that' fixed!